### PR TITLE
Fix SRF football feed URL

### DIFF
--- a/Swiss News Watch App/Models/NewsCategory.swift
+++ b/Swiss News Watch App/Models/NewsCategory.swift
@@ -45,7 +45,7 @@ struct NewsCategory: Identifiable, Codable, Hashable {
         
         // SRF Sport Group
         NewsCategory(id: "srf_sport_all", title: "Sport", feedURL: "https://www.srf.ch/sport/bnf/rss/718", group: .sport, sourceId: "srf"),
-        NewsCategory(id: "srf_sport_football", title: "Fussball", feedURL: "https://www.srf.ch//sport/bnf/rss/2562", group: .sport, sourceId: "srf"),
+        NewsCategory(id: "srf_sport_football", title: "Fussball", feedURL: "https://www.srf.ch/sport/bnf/rss/2562", group: .sport, sourceId: "srf"),
         NewsCategory(id: "srf_sport_hockey", title: "Eishockey", feedURL: "https://www.srf.ch/sport/bnf/rss/3418", group: .sport, sourceId: "srf"),
         NewsCategory(id: "srf_sport_tennis", title: "Tennis", feedURL: "https://www.srf.ch/sport/bnf/rss/2814", group: .sport, sourceId: "srf"),
         NewsCategory(id: "srf_sport_ski", title: "Ski Alpin", feedURL: "https://www.srf.ch/sport/bnf/rss/787950", group: .sport, sourceId: "srf"),


### PR DESCRIPTION
## Summary
- normalize the SRF football feed URL by removing the duplicate slash before `sport`
- leave the category id, title, and RSS path unchanged

## Validation
- `rg -n "srf_sport_football|srf\.ch//sport|srf\.ch/sport/bnf/rss/2562" "Swiss News Watch App/Models/NewsCategory.swift"`
- `curl -I -L --max-time 20 https://www.srf.ch/sport/bnf/rss/2562` returned HTTP 200 with `text/xml`
- `git diff --check`
- `xcodebuild -list` found the `Swiss News Watch App` scheme and resolved packages

I could not complete a local watchOS build because this machine does not have the watchOS 26.5 platform installed, and Xcode reports the local CoreSimulator framework is out of date.